### PR TITLE
Add ability to filter for active users

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -156,6 +156,10 @@ def list_users():
     if user_research_opted_in is not None:
         user_query = user_query.filter(User.user_research_opted_in == convert_to_boolean(user_research_opted_in))
 
+    active = request.args.get('active')
+    if active is not None:
+        user_query = user_query.filter(User.active == convert_to_boolean(active))
+
     return paginated_result_response(
         result_name=RESOURCE_NAME,
         results_query=user_query,


### PR DESCRIPTION
It's very common in scripts that we only want to act on active users. So lots of scripts get a list of users, and then filter for the active users. It would save everyone time and effort if we did that filtering at the API instead.

Increase the page size (from 5 to 10) so all test results fit on one page.